### PR TITLE
Replace redpencilio and remove -service

### DIFF
--- a/ember/.drone.yml
+++ b/ember/.drone.yml
@@ -39,7 +39,6 @@ steps:
 trigger:
   event:
     - pull_request
-
 ---
 kind: pipeline
 type: docker

--- a/ember/.drone.yml
+++ b/ember/.drone.yml
@@ -33,7 +33,7 @@ steps:
 - name: build-dry-run
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
     dry_run: true
     purge: true
 trigger:
@@ -48,7 +48,7 @@ steps:
 - name: push-latest-build
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
     username:
       from_secret: docker_username
     password:
@@ -68,7 +68,7 @@ steps:
 - name: push-tagged-build
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
     tags: ${DRONE_TAG##v}
     username:
       from_secret: docker_username

--- a/ember/.drone.yml
+++ b/ember/.drone.yml
@@ -33,7 +33,7 @@ steps:
 - name: build-dry-run
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME}
     dry_run: true
     purge: true
 trigger:
@@ -47,7 +47,7 @@ steps:
 - name: push-latest-build
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME}
     username:
       from_secret: docker_username
     password:
@@ -67,7 +67,7 @@ steps:
 - name: push-tagged-build
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME}
     tags: ${DRONE_TAG##v}
     username:
       from_secret: docker_username

--- a/ember/README.md
+++ b/ember/README.md
@@ -6,12 +6,14 @@ In this directory you'll find a .drone.yml file with some basic examples of how 
 - release: builds a tagged docker image and pushes it to docker hub, after that publishes on npm.
 
 These pipelines use the  [docker plugin](http://plugins.drone.io/drone-plugins/drone-docker/) and [npm plugin](http://plugins.drone.io/drone-plugins/drone-npm/). They make use of the following [secrets](https://docs.drone.io/secret/) which should be defined on the group or repository in your drone instance:
-- docker_username
-- docker_password
-- npm_access_token
+- `docker_username`
+- `docker_password`
+- `npm_access_token`
 
 
-The pipeline uses the `DRONE_REPO` [pipeline param](https://docs.drone.io/pipeline/environment/reference/) for that. If you this should be different, you have several options:
+The pipeline uses an adapted `DRONE_REPO` [pipeline param](https://docs.drone.io/pipeline/environment/reference/) for the Docker Hub organization.  It renames redpencilio to redpencil which matches our usernames on both GitHub and Docker Hub.
+
+If your situation is different, you have several options:
 
 1. hardcode the correct repository in every pipeline
 2. use drone's [string operations](https://docs.drone.io/pipeline/environment/substitution/) to modify the parameter

--- a/service/.drone.yml
+++ b/service/.drone.yml
@@ -19,6 +19,27 @@ trigger:
 ---
 kind: pipeline
 type: docker
+name: push-feature-build
+steps:
+- name: push-feature-build
+  image: plugins/docker
+  settings:
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
+    tags: ${DRONE_BRANCH/\//-}
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    purge: true
+trigger:
+  branch:
+    - "*/*"
+  event:
+    exclude:
+      - pull_request
+---
+kind: pipeline
+type: docker
 name: push-release
 steps:
 - name: build-and-push-tag

--- a/service/.drone.yml
+++ b/service/.drone.yml
@@ -5,7 +5,7 @@ steps:
 - name: build-and-push
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
     username:
       from_secret: docker_username
     password:
@@ -24,7 +24,7 @@ steps:
 - name: build-and-push-tag
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
     tags: ${DRONE_TAG##v} # strips v from the tag
     username:
       from_secret: docker_username
@@ -41,7 +41,7 @@ steps:
 - name: dry-run
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO}
+    repo: ${DRONE_REPO_NAMESPACE/redpencilio/redpencil}/${DRONE_REPO_NAME%-service}
     dry_run: true
 trigger:
   event:

--- a/service/README.md
+++ b/service/README.md
@@ -11,3 +11,6 @@ The pipeline uses the [docker plugin](http://plugins.drone.io/drone-plugins/dron
 1. hardcode the correct repository in every pipeline
 2. use drone's [string operations](https://docs.drone.io/pipeline/environment/substitution/) to modify the parameter
 
+This pipeline will alter the name of the service to strip -service in the docker hub build.  The -service postfix used on the Git forge is not relevant in the stack where each microservice is a service.  Do remove this stripping for existing services.
+
+This pipeline will also rename the organization on the Git forge if it's redpencilio and change it to redpencil.  This is matching to our usernames on both GitHub and Docker Hub.


### PR DESCRIPTION
- replaces redpencilio to redpencil but leaves other repo namespaces in
  tact.

- removes -service from the repository name as this normally exists on
  GitHub but not on Docker Hub (on all builds).
  
## Next steps

Also update the build for the frontend.