### PR TITLE
feat: add Woodpecker config for building a docker image on each commit

### DIFF
--- a/woodpecker/service/.commit.yml
+++ b/woodpecker/service/.commit.yml
@@ -1,0 +1,11 @@
+steps:
+  build-latest:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
+      tags: "${CI_COMMIT_SHA}"
+      platforms: linux/amd64, linux/arm64
+    secrets: [ docker_username, docker_password ]
+when:
+  branch: master
+  event: push


### PR DESCRIPTION
This config enables that after every commit on master, the Docker image is built and pushed with the commit hash as the tag. This ensures that every master commit can be used as an image. This could be useful for repos that are still WIP (and thus have no versioned releases yet) but see a lot of development (and might introduce bugs on master).

This may also be merged into the `.latest.yml` file, but using an array for the `tags` field, but having it in a separate file might make it more obvious for a repo owner that this behaviour is enabled.