### PR TITLE
Fix tag filter

### DIFF
--- a/woodpecker/ember/addon/.release.yml
+++ b/woodpecker/ember/addon/.release.yml
@@ -10,4 +10,4 @@ steps:
         from_secret: npm_access_token
 when:
   event: tag
-  tag: v*
+  ref: refs/tags/v*

--- a/woodpecker/ember/app/.release.yml
+++ b/woodpecker/ember/app/.release.yml
@@ -7,4 +7,4 @@ steps:
     secrets: [ docker_username, docker_password ]
 when:
   event: tag
-  tag: v*
+  ref: refs/tags/v*

--- a/woodpecker/service/.release.yml
+++ b/woodpecker/service/.release.yml
@@ -8,4 +8,4 @@ steps:
     secrets: [ docker_username, docker_password ]
 when:
   event: tag
-  tag: v*
+  ref: refs/tags/v*


### PR DESCRIPTION
Woodpecker's `tag:` filter was replaced with `ref:` a while ago: https://woodpecker-ci.org/docs/usage/workflow-syntax#ref